### PR TITLE
Zabbix 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ SNMPv2-SMI::enterprises.12740.2.1.1.1.9.1.1234567890 = STRING: "Foo"
                                           ----------            -----------
                                           {$EQL_ID}             {$EQL_NAME}
 ```
+If you get multiple results, i.e. if you extended your storage by additional units, you can create multiple
+hosts for any discovered subsystem with the same snmp hostname.
 
-Now create a macro on the Host
-
+Now create/overload a macro on the Host:
 ```
 {$EQL_ID} -> 1234567890
-{$EQL_NAME} -> foo
+{$EQL_NAME} -> Foo
 {$SNMP_COMMUNITY} -> public
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ You will get something like this:
 
 ```
 SNMPv2-SMI::enterprises.12740.2.1.1.1.9.1.1234567890 = STRING: "Foo"
-
+                                          ----------            -----------
+                                          {$EQL_ID}             {$EQL_NAME}
 ```
 
 Now create a macro on the Host

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Zabbix 3.2 Dell Equallogic
+Zabbix 3.4 Dell Equallogic
 ==========================
 
 This template (ZBX3-DELL-EQUALLOGIC) uses the Equallogic-MIB to discover and manage Equallogic Storage Arrays in Zabbix 3.2.

--- a/zbx3-dell-equallogic.xml
+++ b/zbx3-dell-equallogic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.4</version>
-    <date>2017-12-29T06:00:36Z</date>
+    <date>2018-01-04T20:06:12Z</date>
     <groups>
         <group>
             <name>Template Dell</name>
@@ -50,7 +50,7 @@
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>.1.3.6.1.4.1.12740.2.1.5.1.1.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberHealthStatus</key>
-                    <delay>30</delay>
+                    <delay>60</delay>
                     <history>7d</history>
                     <trends>365d</trends>
                     <status>0</status>
@@ -82,6 +82,47 @@
                     <valuemap>
                         <name>eqlMemberHealthStatus</name>
                     </valuemap>
+                    <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
+                </item>
+                <item>
+                    <name>Raid Rebuild Percentage</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <snmp_oid>.1.3.6.1.4.1.12740.2.1.13.1.2.1.{$EQL_ID}</snmp_oid>
+                    <key>eqlMemberRaidPercentage</key>
+                    <delay>300</delay>
+                    <history>14d</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>General</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
                     <logtimefmt/>
                     <preprocessing/>
                     <jmx_endpoint/>
@@ -214,6 +255,47 @@
                             <params/>
                         </step>
                     </preprocessing>
+                    <jmx_endpoint/>
+                    <master_item/>
+                </item>
+                <item>
+                    <name>OPs Write Percentage</name>
+                    <type>15</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>eqlMemberReadWriteRatio</key>
+                    <delay>120</delay>
+                    <history>7d</history>
+                    <trends>365d</trends>
+                    <status>0</status>
+                    <value_type>0</value_type>
+                    <allowed_hosts/>
+                    <units>%</units>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params>100*last(&quot;eqlMemberWriteOpCount&quot;)/(last(&quot;eqlMemberReadOpCount&quot;)+last(&quot;eqlMemberWriteOpCount&quot;))</params>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>General</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                    <preprocessing/>
                     <jmx_endpoint/>
                     <master_item/>
                 </item>
@@ -1290,7 +1372,7 @@
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <snmp_oid>.1.3.6.1.4.1.12740.3.1.2.1.2.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlDiskStatusBytesRead.[{#SNMPINDEX}]</key>
-                            <delay>60</delay>
+                            <delay>90</delay>
                             <history>7d</history>
                             <trends>365d</trends>
                             <status>0</status>
@@ -1337,7 +1419,7 @@
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <snmp_oid>.1.3.6.1.4.1.12740.3.1.2.1.3.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlDiskStatusBytesWritten.[{#SNMPINDEX}]</key>
-                            <delay>60</delay>
+                            <delay>90</delay>
                             <history>7d</history>
                             <trends>365d</trends>
                             <status>0</status>
@@ -2634,7 +2716,7 @@
                 <screen>
                     <name>Custom - HW - Hardware Dell Equallogic  - Global</name>
                     <hsize>1</hsize>
-                    <vsize>5</vsize>
+                    <vsize>7</vsize>
                     <screen_items>
                         <screen_item>
                             <resourcetype>0</resourcetype>
@@ -2674,7 +2756,7 @@
                             <dynamic>0</dynamic>
                             <sort_triggers>0</sort_triggers>
                             <resource>
-                                <name>Equallogic -  Read/Write OPS</name>
+                                <name>Equallogic - Read/Write OPS Percentage</name>
                                 <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
@@ -2696,7 +2778,7 @@
                             <dynamic>0</dynamic>
                             <sort_triggers>0</sort_triggers>
                             <resource>
-                                <name>Equallogic -  Latency</name>
+                                <name>Equallogic -  Read/Write OPS</name>
                                 <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
@@ -2718,7 +2800,7 @@
                             <dynamic>0</dynamic>
                             <sort_triggers>0</sort_triggers>
                             <resource>
-                                <name>Equallogic -  Storage Usage</name>
+                                <name>Equallogic -  Latency</name>
                                 <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
@@ -2740,7 +2822,51 @@
                             <dynamic>0</dynamic>
                             <sort_triggers>0</sort_triggers>
                             <resource>
+                                <name>Equallogic -  Storage Usage</name>
+                                <host>Custom - HW - Dell Equallogic</host>
+                            </resource>
+                            <max_columns>3</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>5</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
                                 <name>Equallogic -  Storage Usage Overall</name>
+                                <host>Custom - HW - Dell Equallogic</host>
+                            </resource>
+                            <max_columns>3</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>1</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>6</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <key>eqlMemberRaidPercentage</key>
                                 <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
@@ -2976,6 +3102,22 @@
             <tags/>
         </trigger>
         <trigger>
+            <expression>{Custom - HW - Dell Equallogic:eqlMemberRaidPercentage.last()}&lt;100</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Raid Rebuild in progress - {ITEM.VALUE1}%</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>1</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
             <expression>{Custom - HW - Dell Equallogic:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
@@ -3083,6 +3225,38 @@ expanding 	(7)</description>
                     <item>
                         <host>Custom - HW - Dell Equallogic</host>
                         <key>eqlMemberWriteOpCount</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>Equallogic - Read/Write OPS Percentage</name>
+            <width>900</width>
+            <height>200</height>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
+            <show_work_period>1</show_work_period>
+            <show_triggers>1</show_triggers>
+            <type>0</type>
+            <show_legend>1</show_legend>
+            <show_3d>0</show_3d>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
+            <ymin_type_1>1</ymin_type_1>
+            <ymax_type_1>0</ymax_type_1>
+            <ymin_item_1>0</ymin_item_1>
+            <ymax_item_1>0</ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>0</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>1A7C11</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Dell Equallogic</host>
+                        <key>eqlMemberReadWriteRatio</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/zbx3-dell-equallogic.xml
+++ b/zbx3-dell-equallogic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.4</version>
-    <date>2017-12-23T09:42:52Z</date>
+    <date>2017-12-29T06:00:36Z</date>
     <groups>
         <group>
             <name>Template Dell</name>
@@ -131,7 +131,48 @@
                     <master_item/>
                 </item>
                 <item>
-                    <name>Bps read</name>
+                    <name>Latency Read OP</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <snmp_oid>1.3.6.1.4.1.12740.2.1.12.1.4.{$EQL_ID}</snmp_oid>
+                    <key>eqlMemberReadAvgLatency</key>
+                    <delay>120</delay>
+                    <history>7d</history>
+                    <trends>365d</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>ms</units>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>&quot;The average latency for write operations on this member in milli seconds. The value is reset to zero upon reboot.&quot;</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>General</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
+                </item>
+                <item>
+                    <name>OPs read</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.12740.2.1.12.1.6.1.{$EQL_ID}</snmp_oid>
@@ -142,7 +183,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>B</units>
+                    <units>ops</units>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -214,6 +255,56 @@
                     <valuemap/>
                     <logtimefmt/>
                     <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
+                </item>
+                <item>
+                    <name>Data RX</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <snmp_oid>1.3.6.1.4.1.12740.2.1.12.1.9.{$EQL_ID}</snmp_oid>
+                    <key>eqlMemberRxData</key>
+                    <delay>120</delay>
+                    <history>7d</history>
+                    <trends>365d</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>b/sec</units>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>General</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                    <preprocessing>
+                        <step>
+                            <type>10</type>
+                            <params/>
+                        </step>
+                        <step>
+                            <type>1</type>
+                            <params>8</params>
+                        </step>
+                    </preprocessing>
                     <jmx_endpoint/>
                     <master_item/>
                 </item>
@@ -305,6 +396,56 @@
                     <master_item/>
                 </item>
                 <item>
+                    <name>Data TX</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <snmp_oid>1.3.6.1.4.1.12740.2.1.12.1.8.{$EQL_ID}</snmp_oid>
+                    <key>eqlMemberTxData</key>
+                    <delay>120</delay>
+                    <history>7d</history>
+                    <trends>365d</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>b/sec</units>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>General</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                    <preprocessing>
+                        <step>
+                            <type>10</type>
+                            <params/>
+                        </step>
+                        <step>
+                            <type>1</type>
+                            <params>8</params>
+                        </step>
+                    </preprocessing>
+                    <jmx_endpoint/>
+                    <master_item/>
+                </item>
+                <item>
                     <name>Used Storage</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
@@ -351,7 +492,48 @@
                     <master_item/>
                 </item>
                 <item>
-                    <name>Bps written</name>
+                    <name>Latency Write OP</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <snmp_oid>1.3.6.1.4.1.12740.2.1.12.1.5.{$EQL_ID}</snmp_oid>
+                    <key>eqlMemberWriteAvgLatency</key>
+                    <delay>120</delay>
+                    <history>7d</history>
+                    <trends>365d</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>ms</units>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>&quot;The average latency for read operations on this member in milli seconds. The value is reset to zero upon reboot.&quot;</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>General</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
+                </item>
+                <item>
+                    <name>OPs write</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.12740.2.1.12.1.7.1.{$EQL_ID}</snmp_oid>
@@ -362,7 +544,7 @@
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
-                    <units>B</units>
+                    <units>ops</units>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -2452,7 +2634,7 @@
                 <screen>
                     <name>Custom - HW - Hardware Dell Equallogic  - Global</name>
                     <hsize>1</hsize>
-                    <vsize>3</vsize>
+                    <vsize>5</vsize>
                     <screen_items>
                         <screen_item>
                             <resourcetype>0</resourcetype>
@@ -2470,7 +2652,7 @@
                             <dynamic>0</dynamic>
                             <sort_triggers>0</sort_triggers>
                             <resource>
-                                <name>Equallogic -  Read/Write stats</name>
+                                <name>Equallogic -  RX/TX Data</name>
                                 <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
@@ -2492,7 +2674,7 @@
                             <dynamic>0</dynamic>
                             <sort_triggers>0</sort_triggers>
                             <resource>
-                                <name>Equallogic -  Storage Usage</name>
+                                <name>Equallogic -  Read/Write OPS</name>
                                 <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
@@ -2504,6 +2686,50 @@
                             <height>300</height>
                             <x>0</x>
                             <y>2</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Equallogic -  Latency</name>
+                                <host>Custom - HW - Dell Equallogic</host>
+                            </resource>
+                            <max_columns>3</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>3</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Equallogic -  Storage Usage</name>
+                                <host>Custom - HW - Dell Equallogic</host>
+                            </resource>
+                            <max_columns>3</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>4</y>
                             <colspan>1</colspan>
                             <rowspan>1</rowspan>
                             <elements>0</elements>
@@ -2774,7 +3000,51 @@ expanding 	(7)</description>
     </triggers>
     <graphs>
         <graph>
-            <name>Equallogic -  Read/Write stats</name>
+            <name>Equallogic -  Latency</name>
+            <width>900</width>
+            <height>300</height>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
+            <show_work_period>1</show_work_period>
+            <show_triggers>1</show_triggers>
+            <type>0</type>
+            <show_legend>1</show_legend>
+            <show_3d>0</show_3d>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
+            <ymin_type_1>1</ymin_type_1>
+            <ymax_type_1>0</ymax_type_1>
+            <ymin_item_1>0</ymin_item_1>
+            <ymax_item_1>0</ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>0</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>2774A4</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Dell Equallogic</host>
+                        <key>eqlMemberReadAvgLatency</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>A54F10</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Dell Equallogic</host>
+                        <key>eqlMemberWriteAvgLatency</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>Equallogic -  Read/Write OPS</name>
             <width>900</width>
             <height>300</height>
             <yaxismin>0.0000</yaxismin>
@@ -2813,6 +3083,50 @@ expanding 	(7)</description>
                     <item>
                         <host>Custom - HW - Dell Equallogic</host>
                         <key>eqlMemberWriteOpCount</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>Equallogic -  RX/TX Data</name>
+            <width>900</width>
+            <height>300</height>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
+            <show_work_period>1</show_work_period>
+            <show_triggers>1</show_triggers>
+            <type>1</type>
+            <show_legend>1</show_legend>
+            <show_3d>0</show_3d>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
+            <ymin_type_1>1</ymin_type_1>
+            <ymax_type_1>0</ymax_type_1>
+            <ymin_item_1>0</ymin_item_1>
+            <ymax_item_1>0</ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>0</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>00AA00</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Dell Equallogic</host>
+                        <key>eqlMemberTxData</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>BB0000</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Dell Equallogic</host>
+                        <key>eqlMemberRxData</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/zbx3-dell-equallogic.xml
+++ b/zbx3-dell-equallogic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.4</version>
-    <date>2017-12-22T09:49:47Z</date>
+    <date>2017-12-22T10:30:53Z</date>
     <groups>
         <group>
             <name>Template Dell</name>
@@ -12,8 +12,8 @@
     </groups>
     <templates>
         <template>
-            <template>Custom - HW - Hardware Dell Equallogic</template>
-            <name>Custom - HW - Hardware Dell Equallogic</name>
+            <template>Custom - HW - Hardware Dell Equallogic - MainUnit</template>
+            <name>Custom - HW - Hardware Dell Equallogic - MainUnit</name>
             <description/>
             <groups>
                 <group>
@@ -518,7 +518,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlControllerBatteryStatus.[{#SNMPINDEX}].last()}&lt;&gt;1</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlControllerBatteryStatus.[{#SNMPINDEX}].last()}&lt;&gt;1</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>Battery Controller Status</name>
@@ -659,7 +659,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}].last()}&lt;&gt;1</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}].last()}&lt;&gt;1</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>Fan Failure</name>
@@ -702,7 +702,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqlMemberHealthDetailsFanValue.[{#SNMPVALUE}]</key>
                                     </item>
                                 </graph_item>
@@ -915,7 +915,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>High Temperature in {#SNMPVALUE}</name>
@@ -931,7 +931,7 @@
                             <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;0</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;0</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Temperature Status</name>
@@ -974,7 +974,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}]</key>
                                     </item>
                                 </graph_item>
@@ -1251,7 +1251,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic - MainUnit:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Disk 1 Status</name>
@@ -1294,7 +1294,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqlDiskStatusBytesRead.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1306,7 +1306,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqlDiskStatusBytesWritten.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1318,7 +1318,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqlDiskStatusTotalQD.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1502,7 +1502,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic:poolpercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;98</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:poolpercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;98</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Pool {ITEM.LASTVALUE} Used</name>
@@ -1545,7 +1545,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqlStoragePoolStatsSpace.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -1557,7 +1557,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqlStoragePoolStatsSpaceUsed.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2195,7 +2195,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;2 and {Custom - HW - Hardware Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;4</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;2 and {Custom - HW - Hardware Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;4</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Volume Admin Status</name>
@@ -2211,7 +2211,7 @@
                             <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic:volumepercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;99</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:volumepercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;99</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Volume {ITEM.LASTVALUE} Used</name>
@@ -2254,7 +2254,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqliscsiVolumeStatsTxData.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2266,7 +2266,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqliscsiVolumeStatsRxData.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2298,7 +2298,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqliscsiVolumeStatsReadOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2310,7 +2310,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>eqliscsiVolumeStatsWriteOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2342,7 +2342,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>volumeReadAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2354,7 +2354,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                                         <key>volumeWriteAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2400,7 +2400,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Disk {#SNMPINDEX} Activity</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2429,7 +2429,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Fan Speed of {#SNMPVALUE}</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2458,7 +2458,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Read/Write stats</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2480,7 +2480,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Storage Usage</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2502,7 +2502,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Storage Usage Overall</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2531,7 +2531,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Pool Space</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2560,7 +2560,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume IOPS</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2582,7 +2582,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume Bps</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2604,7 +2604,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume Latency</name>
-                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2616,7 +2616,7 @@
     </templates>
     <triggers>
         <trigger>
-            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Health Status</name>
@@ -2632,7 +2632,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Hardware Dell Equallogic:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
+            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>low free Storage (&gt;95%)</name>
@@ -2648,7 +2648,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthStatus.nodata(600)}=1</expression>
+            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthStatus.nodata(600)}=1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>no SNMP-Data recieved since &gt;10m</name>
@@ -2664,7 +2664,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Raid Status</name>
@@ -2707,7 +2707,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                         <key>eqlMemberReadOpCount</key>
                     </item>
                 </graph_item>
@@ -2719,7 +2719,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                         <key>eqlMemberWriteOpCount</key>
                     </item>
                 </graph_item>
@@ -2751,7 +2751,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                         <key>eqlMemberUsedStorage</key>
                     </item>
                 </graph_item>
@@ -2763,7 +2763,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                         <key>eqlMemberReplStorage</key>
                     </item>
                 </graph_item>
@@ -2775,7 +2775,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                         <key>eqlMemberSnapStorage</key>
                     </item>
                 </graph_item>
@@ -2807,7 +2807,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
                         <key>MemberUsedStoragePercent</key>
                     </item>
                 </graph_item>

--- a/zbx3-dell-equallogic.xml
+++ b/zbx3-dell-equallogic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.4</version>
-    <date>2017-12-22T12:55:47Z</date>
+    <date>2017-12-23T09:42:52Z</date>
     <groups>
         <group>
             <name>Template Dell</name>
@@ -14,7 +14,7 @@
         <template>
             <template>Custom - HW - Dell Equallogic</template>
             <name>Custom - HW - Dell Equallogic</name>
-            <description/>
+            <description>http://www.mibdepot.com/cgi-bin/getmib3.cgi?win=mib_a&amp;r=equallogic&amp;f=eqlmember.mib&amp;v=v2&amp;t=tree</description>
             <groups>
                 <group>
                     <name>Template Dell</name>
@@ -440,12 +440,12 @@
             </items>
             <discovery_rules>
                 <discovery_rule>
-                    <name>Main Controller Battery status</name>
+                    <name>Controller Battery status</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.4.1.1.1.5.1.{$EQL_ID}]</snmp_oid>
                     <key>eqlControllerBatteryStatus</key>
-                    <delay>600</delay>
+                    <delay>1200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -539,12 +539,12 @@
                     <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Main Fan sensors</name>
+                    <name>Fan sensors</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.2.1.7.1.2.1.{$EQL_ID}]</snmp_oid>
                     <key>eqlMemberHealthDetailsFanName</key>
-                    <delay>600</delay>
+                    <delay>1200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -713,12 +713,12 @@
                     <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Main Power Supply</name>
+                    <name>Power Supply</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.2.1.8.1.2.1.{$EQL_ID}]</snmp_oid>
                     <key>eqlMemberHealthDetailsPowerSupply</key>
-                    <delay>600</delay>
+                    <delay>1200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -795,12 +795,12 @@
                     <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Main Temperature sensors</name>
+                    <name>Temperature sensors</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.2.1.6.1.2.1.{$EQL_ID}]</snmp_oid>
                     <key>eqlMemberHealthDetailsTemperatureName</key>
-                    <delay>600</delay>
+                    <delay>1200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -871,6 +871,48 @@
                             <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
+                            <name>Temperature of {#SNMPVALUE} Critical Threshhold</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <snmp_oid>1.3.6.1.4.1.12740.2.1.6.1.5.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
+                            <key>eqlMemberHealthDetailsTemperatureHighCriticalThreshold.[{#SNMPVALUE}]</key>
+                            <delay>1200</delay>
+                            <history>2d</history>
+                            <trends>365d</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>C</units>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>Temperature</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
+                            <application_prototypes/>
+                            <master_item_prototype/>
+                        </item_prototype>
+                        <item_prototype>
                             <name>Temperature of {#SNMPVALUE}</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
@@ -915,7 +957,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
+                            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;	{Custom - HW - Dell Equallogic:eqlMemberHealthDetailsTemperatureHighCriticalThreshold.[{#SNMPVALUE}].last()}</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>High Temperature in {#SNMPVALUE}</name>
@@ -985,12 +1027,12 @@
                     <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Main Disk stats</name>
+                    <name>Disk stats</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.12740.3.1.1.1.10.1.{$EQL_ID}]</snmp_oid>
                     <key>snmp.discovery.sanmembers</key>
-                    <delay>600</delay>
+                    <delay>1200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -1329,12 +1371,12 @@
                     <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Main SAN pools</name>
+                    <name>SAN pools</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.16.1.1.1.3.1]</snmp_oid>
                     <key>snmp.discovery.sanpools</key>
-                    <delay>600</delay>
+                    <delay>1200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -1568,12 +1610,12 @@
                     <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Main SAN volumes</name>
+                    <name>SAN volumes</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.5.1.7.1.1.4.{$EQL_ID}]</snmp_oid>
                     <key>snmp.discovery.sanvolumes</key>
-                    <delay>600</delay>
+                    <delay>1200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -2408,38 +2450,9 @@
                     </screen_items>
                 </screen>
                 <screen>
-                    <name>Custom - HW - Hardware Dell Equallogic - Fan sensors</name>
-                    <hsize>1</hsize>
-                    <vsize>1</vsize>
-                    <screen_items>
-                        <screen_item>
-                            <resourcetype>20</resourcetype>
-                            <width>900</width>
-                            <height>300</height>
-                            <x>0</x>
-                            <y>0</y>
-                            <colspan>1</colspan>
-                            <rowspan>1</rowspan>
-                            <elements>0</elements>
-                            <valign>0</valign>
-                            <halign>0</halign>
-                            <style>0</style>
-                            <url/>
-                            <dynamic>0</dynamic>
-                            <sort_triggers>0</sort_triggers>
-                            <resource>
-                                <name>Fan Speed of {#SNMPVALUE}</name>
-                                <host>Custom - HW - Dell Equallogic</host>
-                            </resource>
-                            <max_columns>1</max_columns>
-                            <application/>
-                        </screen_item>
-                    </screen_items>
-                </screen>
-                <screen>
                     <name>Custom - HW - Hardware Dell Equallogic  - Global</name>
                     <hsize>1</hsize>
-                    <vsize>4</vsize>
+                    <vsize>3</vsize>
                     <screen_items>
                         <screen_item>
                             <resourcetype>0</resourcetype>
@@ -2611,15 +2624,66 @@
                         </screen_item>
                     </screen_items>
                 </screen>
+                <screen>
+                    <name>Custom - HW - Hardware Dell Equallogic - Temperature</name>
+                    <hsize>1</hsize>
+                    <vsize>2</vsize>
+                    <screen_items>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <width>600</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>1</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Temperature of {#SNMPVALUE}</name>
+                                <host>Custom - HW - Dell Equallogic</host>
+                            </resource>
+                            <max_columns>2</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <width>600</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>1</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>1</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Fan Speed of {#SNMPVALUE}</name>
+                                <host>Custom - HW - Dell Equallogic</host>
+                            </resource>
+                            <max_columns>2</max_columns>
+                            <application/>
+                        </screen_item>
+                    </screen_items>
+                </screen>
             </screens>
         </template>
     </templates>
     <triggers>
         <trigger>
-            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthStatus.max(#2)}&gt;2</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
-            <name>Health Status</name>
+            <name>Health Status Critical</name>
             <correlation_mode>0</correlation_mode>
             <correlation_tag/>
             <url/>
@@ -2632,10 +2696,32 @@
             <tags/>
         </trigger>
         <trigger>
+            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthStatus.max(#2)}&gt;1</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Health Status Warning</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>3</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies>
+                <dependency>
+                    <name>Health Status Critical</name>
+                    <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthStatus.max(#2)}&gt;2</expression>
+                    <recovery_expression/>
+                </dependency>
+            </dependencies>
+            <tags/>
+        </trigger>
+        <trigger>
             <expression>{Custom - HW - Dell Equallogic:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
-            <name>low free Storage (&gt;95%)</name>
+            <name>Low Free Storage (usage &gt;95%)</name>
             <correlation_mode>0</correlation_mode>
             <correlation_tag/>
             <url/>
@@ -2667,13 +2753,19 @@
             <expression>{Custom - HW - Dell Equallogic:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
-            <name>Raid Status</name>
+            <name>Raid Status - {ITEM.VALUE1}</name>
             <correlation_mode>0</correlation_mode>
             <correlation_tag/>
             <url/>
             <status>0</status>
             <priority>4</priority>
-            <description/>
+            <description>ok 	(1),	 &#13;
+degraded 	(2),	 &#13;
+verifying 	(3),	 &#13;
+reconstructing 	(4),	 &#13;
+failed 	(5),	 &#13;
+catastrophicLoss 	(6),	 &#13;
+expanding 	(7)</description>
             <type>0</type>
             <manual_close>0</manual_close>
             <dependencies/>

--- a/zbx3-dell-equallogic.xml
+++ b/zbx3-dell-equallogic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.4</version>
-    <date>2017-12-22T10:30:53Z</date>
+    <date>2017-12-22T11:35:43Z</date>
     <groups>
         <group>
             <name>Template Dell</name>
@@ -12,8 +12,8 @@
     </groups>
     <templates>
         <template>
-            <template>Custom - HW - Hardware Dell Equallogic - MainUnit</template>
-            <name>Custom - HW - Hardware Dell Equallogic - MainUnit</name>
+            <template>Custom - HW - Dell Equallogic - MainUnit</template>
+            <name>Custom - HW - Dell Equallogic - MainUnit</name>
             <description/>
             <groups>
                 <group>
@@ -518,7 +518,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlControllerBatteryStatus.[{#SNMPINDEX}].last()}&lt;&gt;1</expression>
+                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlControllerBatteryStatus.[{#SNMPINDEX}].last()}&lt;&gt;1</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>Battery Controller Status</name>
@@ -659,7 +659,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}].last()}&lt;&gt;1</expression>
+                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}].last()}&lt;&gt;1</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>Fan Failure</name>
@@ -702,7 +702,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqlMemberHealthDetailsFanValue.[{#SNMPVALUE}]</key>
                                     </item>
                                 </graph_item>
@@ -915,7 +915,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
+                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>High Temperature in {#SNMPVALUE}</name>
@@ -931,7 +931,7 @@
                             <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;0</expression>
+                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;1 and {Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;0</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Temperature Status</name>
@@ -974,7 +974,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}]</key>
                                     </item>
                                 </graph_item>
@@ -1251,7 +1251,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic - MainUnit:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2</expression>
+                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;1 and {Custom - HW - Dell Equallogic - MainUnit:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Disk 1 Status</name>
@@ -1294,7 +1294,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqlDiskStatusBytesRead.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1306,7 +1306,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqlDiskStatusBytesWritten.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1318,7 +1318,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqlDiskStatusTotalQD.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1502,7 +1502,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:poolpercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;98</expression>
+                            <expression>{Custom - HW - Dell Equallogic - MainUnit:poolpercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;98</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Pool {ITEM.LASTVALUE} Used</name>
@@ -1545,7 +1545,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqlStoragePoolStatsSpace.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -1557,7 +1557,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqlStoragePoolStatsSpaceUsed.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2195,7 +2195,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;2 and {Custom - HW - Hardware Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;4</expression>
+                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;1 and {Custom - HW - Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;2 and {Custom - HW - Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;4</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Volume Admin Status</name>
@@ -2211,7 +2211,7 @@
                             <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:volumepercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;99</expression>
+                            <expression>{Custom - HW - Dell Equallogic - MainUnit:volumepercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;99</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Volume {ITEM.LASTVALUE} Used</name>
@@ -2254,7 +2254,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqliscsiVolumeStatsTxData.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2266,7 +2266,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqliscsiVolumeStatsRxData.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2298,7 +2298,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqliscsiVolumeStatsReadOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2310,7 +2310,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>eqliscsiVolumeStatsWriteOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2342,7 +2342,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>volumeReadAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2354,7 +2354,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                                         <key>volumeWriteAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2400,7 +2400,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Disk {#SNMPINDEX} Activity</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2429,7 +2429,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Fan Speed of {#SNMPVALUE}</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2458,7 +2458,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Read/Write stats</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2480,7 +2480,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Storage Usage</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2502,7 +2502,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Storage Usage Overall</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2531,7 +2531,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Pool Space</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2560,7 +2560,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume IOPS</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2582,7 +2582,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume Bps</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2604,7 +2604,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume Latency</name>
-                                <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2616,7 +2616,7 @@
     </templates>
     <triggers>
         <trigger>
-            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Health Status</name>
@@ -2632,7 +2632,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
+            <expression>{Custom - HW - Dell Equallogic - MainUnit:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>low free Storage (&gt;95%)</name>
@@ -2648,7 +2648,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberHealthStatus.nodata(600)}=1</expression>
+            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthStatus.nodata(600)}=1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>no SNMP-Data recieved since &gt;10m</name>
@@ -2664,7 +2664,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Hardware Dell Equallogic - MainUnit:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Raid Status</name>
@@ -2707,7 +2707,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                         <key>eqlMemberReadOpCount</key>
                     </item>
                 </graph_item>
@@ -2719,7 +2719,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                         <key>eqlMemberWriteOpCount</key>
                     </item>
                 </graph_item>
@@ -2751,7 +2751,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                         <key>eqlMemberUsedStorage</key>
                     </item>
                 </graph_item>
@@ -2763,7 +2763,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                         <key>eqlMemberReplStorage</key>
                     </item>
                 </graph_item>
@@ -2775,7 +2775,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                         <key>eqlMemberSnapStorage</key>
                     </item>
                 </graph_item>
@@ -2807,7 +2807,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Hardware Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
                         <key>MemberUsedStoragePercent</key>
                     </item>
                 </graph_item>

--- a/zbx3-dell-equallogic.xml
+++ b/zbx3-dell-equallogic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>3.2</version>
-    <date>2017-03-08T14:26:48Z</date>
+    <version>3.4</version>
+    <date>2017-12-22T09:49:47Z</date>
     <groups>
         <group>
             <name>Template Dell</name>
@@ -12,8 +12,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template Dell Equallogic</template>
-            <name>Template Dell Equallogic</name>
+            <template>Custom - HW - Hardware Dell Equallogic</template>
+            <name>Custom - HW - Hardware Dell Equallogic</name>
             <description/>
             <groups>
                 <group>
@@ -25,22 +25,22 @@
             </groups>
             <applications>
                 <application>
-                    <name>Disks</name>
-                </application>
-                <application>
-                    <name>Fan</name>
-                </application>
-                <application>
                     <name>General</name>
                 </application>
                 <application>
-                    <name>Pools</name>
+                    <name>Main Unit - Disks</name>
                 </application>
                 <application>
-                    <name>Temperature</name>
+                    <name>Main Unit - Fan</name>
                 </application>
                 <application>
-                    <name>Volume</name>
+                    <name>Main Unit - Pools</name>
+                </application>
+                <application>
+                    <name>Main Unit - Temperature</name>
+                </application>
+                <application>
+                    <name>Main Unit - Volume</name>
                 </application>
             </applications>
             <items>
@@ -48,17 +48,15 @@
                     <name>Health status</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.12740.2.1.5.1.1.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberHealthStatus</key>
                     <delay>30</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units/>
-                    <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -66,11 +64,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -88,22 +83,23 @@
                         <name>eqlMemberHealthStatus</name>
                     </valuemap>
                     <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
                 <item>
                     <name>Raid Status</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.12740.2.1.13.1.1.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberRaidStatus</key>
                     <delay>120</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units/>
-                    <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -111,11 +107,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -133,22 +126,23 @@
                         <name>eqlMemberRaidStatus</name>
                     </valuemap>
                     <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
                 <item>
                     <name>Bps read</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.12740.2.1.12.1.6.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberReadOpCount</key>
                     <delay>120</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units>B</units>
-                    <delta>1</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -156,11 +150,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -176,22 +167,28 @@
                     </applications>
                     <valuemap/>
                     <logtimefmt/>
+                    <preprocessing>
+                        <step>
+                            <type>10</type>
+                            <params/>
+                        </step>
+                    </preprocessing>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
                 <item>
                     <name>Used replication space</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.12740.2.1.10.1.4.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberReplStorage</key>
                     <delay>900</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units/>
-                    <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -199,11 +196,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -219,22 +213,23 @@
                     </applications>
                     <valuemap/>
                     <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
                 <item>
                     <name>Used snapshot space</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.12740.2.1.10.1.3.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberSnapStorage</key>
                     <delay>600</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units/>
-                    <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -242,11 +237,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -262,22 +254,23 @@
                     </applications>
                     <valuemap/>
                     <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
                 <item>
                     <name>Total Storage</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>1</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.12740.2.1.10.1.1.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberTotalStorage</key>
                     <delay>3600</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units>b</units>
-                    <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -285,11 +278,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1048576</formula>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -305,22 +295,28 @@
                     </applications>
                     <valuemap/>
                     <logtimefmt/>
+                    <preprocessing>
+                        <step>
+                            <type>1</type>
+                            <params>1048576</params>
+                        </step>
+                    </preprocessing>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
                 <item>
                     <name>Used Storage</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>1</multiplier>
                     <snmp_oid>.1.3.6.1.4.1.12740.2.1.10.1.2.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberUsedStorage</key>
                     <delay>300</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units>B</units>
-                    <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -328,11 +324,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1048576</formula>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -348,22 +341,28 @@
                     </applications>
                     <valuemap/>
                     <logtimefmt/>
+                    <preprocessing>
+                        <step>
+                            <type>1</type>
+                            <params>1048576</params>
+                        </step>
+                    </preprocessing>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
                 <item>
                     <name>Bps written</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.12740.2.1.12.1.7.1.{$EQL_ID}</snmp_oid>
                     <key>eqlMemberWriteOpCount</key>
                     <delay>120</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units>B</units>
-                    <delta>1</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -371,11 +370,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -391,22 +387,28 @@
                     </applications>
                     <valuemap/>
                     <logtimefmt/>
+                    <preprocessing>
+                        <step>
+                            <type>10</type>
+                            <params/>
+                        </step>
+                    </preprocessing>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
                 <item>
                     <name>Used Storage Percent</name>
                     <type>15</type>
                     <snmp_community/>
-                    <multiplier>0</multiplier>
                     <snmp_oid/>
                     <key>MemberUsedStoragePercent</key>
                     <delay>300</delay>
-                    <history>7</history>
-                    <trends>365</trends>
+                    <history>7d</history>
+                    <trends>365d</trends>
                     <status>0</status>
                     <value_type>3</value_type>
                     <allowed_hosts/>
                     <units>%</units>
-                    <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
                     <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -414,11 +416,8 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
                     <params>100*last(&quot;eqlMemberUsedStorage&quot;,0) /last(&quot;eqlMemberTotalStorage&quot;,0)</params>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -434,16 +433,19 @@
                     </applications>
                     <valuemap/>
                     <logtimefmt/>
+                    <preprocessing/>
+                    <jmx_endpoint/>
+                    <master_item/>
                 </item>
             </items>
             <discovery_rules>
                 <discovery_rule>
-                    <name>Controller Battery status</name>
+                    <name>Main Controller Battery status</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.4.1.1.1.5.1.{$EQL_ID}]</snmp_oid>
                     <key>eqlControllerBatteryStatus</key>
-                    <delay>3600</delay>
+                    <delay>600</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -453,7 +455,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -467,24 +468,22 @@
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>30</lifetime>
+                    <lifetime>30d</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
                             <name>Controller {#SNMPINDEX} Battery status</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.4.1.1.1.5.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlControllerBatteryStatus.[{#SNMPINDEX}]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -492,11 +491,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -514,12 +510,15 @@
                                 <name>eqlControllerBatteryStatus</name>
                             </valuemap>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template Dell Equallogic:eqlControllerBatteryStatus.[{#SNMPINDEX}].last()}&lt;&gt;1</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlControllerBatteryStatus.[{#SNMPINDEX}].last()}&lt;&gt;1</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>Battery Controller Status</name>
@@ -537,14 +536,15 @@
                     </trigger_prototypes>
                     <graph_prototypes/>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Fan sensors</name>
+                    <name>Main Fan sensors</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.2.1.7.1.2.1.{$EQL_ID}]</snmp_oid>
                     <key>eqlMemberHealthDetailsFanName</key>
-                    <delay>3600</delay>
+                    <delay>600</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -554,7 +554,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -568,24 +567,22 @@
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>30</lifetime>
+                    <lifetime>30d</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
                             <name>Status of {#SNMPVALUE}</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.2.1.7.1.4.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}]</key>
                             <delay>120</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -593,11 +590,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -608,30 +602,31 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Fan</name>
+                                    <name>Main Unit - Fan</name>
                                 </application>
                             </applications>
                             <valuemap>
                                 <name>eqlMemberHealthDetailsFanCurrentState</name>
                             </valuemap>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>Fan Speed of {#SNMPVALUE}</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.2.1.7.1.3.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlMemberHealthDetailsFanValue.[{#SNMPVALUE}]</key>
                             <delay>120</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -639,11 +634,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -654,17 +646,20 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Fan</name>
+                                    <name>Main Unit - Fan</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template Dell Equallogic:eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}].last()}&lt;&gt;1</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}].last()}&lt;&gt;1</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>Fan Failure</name>
@@ -680,16 +675,50 @@
                             <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
-                    <graph_prototypes/>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>Fan Speed of {#SNMPVALUE}</name>
+                            <width>900</width>
+                            <height>300</height>
+                            <yaxismin>0.0000</yaxismin>
+                            <yaxismax>100.0000</yaxismax>
+                            <show_work_period>1</show_work_period>
+                            <show_triggers>1</show_triggers>
+                            <type>0</type>
+                            <show_legend>1</show_legend>
+                            <show_3d>0</show_3d>
+                            <percent_left>0.0000</percent_left>
+                            <percent_right>0.0000</percent_right>
+                            <ymin_type_1>1</ymin_type_1>
+                            <ymax_type_1>0</ymax_type_1>
+                            <ymin_item_1>0</ymin_item_1>
+                            <ymax_item_1>0</ymax_item_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>0</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>1A7C11</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>4</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <key>eqlMemberHealthDetailsFanValue.[{#SNMPVALUE}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Power Supply</name>
+                    <name>Main Power Supply</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.2.1.8.1.2.1.{$EQL_ID}]</snmp_oid>
                     <key>eqlMemberHealthDetailsPowerSupply</key>
-                    <delay>3600</delay>
+                    <delay>600</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -699,7 +728,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -713,24 +741,22 @@
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>30</lifetime>
+                    <lifetime>30d</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
                             <name>Status of {#SNMPVALUE}</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.2.1.8.1.3.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlMemberHealthDetailsPowerSupplyEntry.[{#SNMPVALUE}]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -738,11 +764,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -760,20 +783,24 @@
                                 <name>eqlMemberHealthDetailsPowerSupplyCurrentState</name>
                             </valuemap>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes/>
                     <graph_prototypes/>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Temperature sensors</name>
+                    <name>Main Temperature sensors</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.2.1.6.1.2.1.{$EQL_ID}]</snmp_oid>
                     <key>eqlMemberHealthDetailsTemperatureName</key>
-                    <delay>3600</delay>
+                    <delay>600</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -783,7 +810,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -797,24 +823,22 @@
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>1</lifetime>
+                    <lifetime>30d</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
                             <name>Temperature Status of {#SNMPVALUE}</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.2.1.6.1.4.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -822,11 +846,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -837,30 +858,31 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Temperature</name>
+                                    <name>Main Unit - Temperature</name>
                                 </application>
                             </applications>
                             <valuemap>
                                 <name>eqlMemberHealthDetailsTemperatureCurrentState</name>
                             </valuemap>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>Temperature of {#SNMPVALUE}</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.12740.2.1.6.1.3.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>C</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -868,11 +890,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -883,17 +902,20 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Temperature</name>
+                                    <name>Main Unit - Temperature</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template Dell Equallogic:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>High Temperature in {#SNMPVALUE}</name>
@@ -909,7 +931,7 @@
                             <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template Dell Equallogic:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;1 and {Template Dell Equallogic:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;0</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;0</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Temperature Status</name>
@@ -925,16 +947,50 @@
                             <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
-                    <graph_prototypes/>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>Temperature of {#SNMPVALUE}</name>
+                            <width>900</width>
+                            <height>300</height>
+                            <yaxismin>0.0000</yaxismin>
+                            <yaxismax>100.0000</yaxismax>
+                            <show_work_period>1</show_work_period>
+                            <show_triggers>1</show_triggers>
+                            <type>0</type>
+                            <show_legend>1</show_legend>
+                            <show_3d>0</show_3d>
+                            <percent_left>0.0000</percent_left>
+                            <percent_right>0.0000</percent_right>
+                            <ymin_type_1>1</ymin_type_1>
+                            <ymax_type_1>0</ymax_type_1>
+                            <ymin_item_1>0</ymin_item_1>
+                            <ymax_item_1>0</ymax_item_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>0</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>1A7C11</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>4</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <key>eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Disk stats</name>
+                    <name>Main Disk stats</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.12740.3.1.1.1.10.1.{$EQL_ID}]</snmp_oid>
                     <key>snmp.discovery.sanmembers</key>
-                    <delay>3600</delay>
+                    <delay>600</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -944,7 +1000,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -958,24 +1013,22 @@
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>30</lifetime>
+                    <lifetime>30d</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} status</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.3.1.1.1.8.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlDiskStatus.[{#SNMPINDEX}]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -983,11 +1036,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -998,30 +1048,31 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Disks</name>
+                                    <name>Main Unit - Disks</name>
                                 </application>
                             </applications>
                             <valuemap>
                                 <name>eqlDiskStatus</name>
                             </valuemap>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} total bytes read</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>1</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.3.1.2.1.2.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlDiskStatusBytesRead.[{#SNMPINDEX}]</key>
                             <delay>60</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>B</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1029,11 +1080,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1000000</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1044,28 +1092,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Disks</name>
+                                    <name>Main Unit - Disks</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1000000</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} total bytes written</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>1</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.3.1.2.1.3.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlDiskStatusBytesWritten.[{#SNMPINDEX}]</key>
                             <delay>60</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>B</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1073,11 +1127,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1000000</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1088,28 +1139,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Disks</name>
+                                    <name>Main Unit - Disks</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1000000</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} total queue depth</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.3.1.2.1.8.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlDiskStatusTotalQD.[{#SNMPINDEX}]</key>
                             <delay>120</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>2</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1117,11 +1174,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1132,28 +1186,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Disks</name>
+                                    <name>Main Unit - Disks</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>9</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} succesful transfers</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.3.1.2.1.1.1.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqlDiskStatusXfers.[{#SNMPINDEX}]</key>
                             <delay>120</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>2</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1161,11 +1221,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1176,17 +1233,25 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Disks</name>
+                                    <name>Main Unit - Disks</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>9</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template Dell Equallogic:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;1 and {Template Dell Equallogic:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Disk 1 Status</name>
@@ -1202,16 +1267,74 @@
                             <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
-                    <graph_prototypes/>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>Disk {#SNMPINDEX} Activity</name>
+                            <width>900</width>
+                            <height>300</height>
+                            <yaxismin>0.0000</yaxismin>
+                            <yaxismax>100.0000</yaxismax>
+                            <show_work_period>1</show_work_period>
+                            <show_triggers>1</show_triggers>
+                            <type>0</type>
+                            <show_legend>1</show_legend>
+                            <show_3d>0</show_3d>
+                            <percent_left>0.0000</percent_left>
+                            <percent_right>0.0000</percent_right>
+                            <ymin_type_1>1</ymin_type_1>
+                            <ymax_type_1>0</ymax_type_1>
+                            <ymin_item_1>0</ymin_item_1>
+                            <ymax_item_1>0</ymax_item_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>0</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>1A7C11</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>4</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <key>eqlDiskStatusBytesRead.[{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>F63100</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>4</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <key>eqlDiskStatusBytesWritten.[{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>2</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>2774A4</color>
+                                    <yaxisside>1</yaxisside>
+                                    <calc_fnc>4</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <key>eqlDiskStatusTotalQD.[{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>SAN pools</name>
+                    <name>Main SAN pools</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.16.1.1.1.3.1]</snmp_oid>
                     <key>snmp.discovery.sanpools</key>
-                    <delay>3600</delay>
+                    <delay>600</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -1221,7 +1344,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -1235,24 +1357,22 @@
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>30</lifetime>
+                    <lifetime>30d</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
                             <name>{#SNMPVALUE} Pool Space</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>1</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.16.1.2.1.1.1.{#SNMPINDEX}</snmp_oid>
                             <key>eqlStoragePoolStatsSpace.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>B</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1260,11 +1380,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1048576</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1278,28 +1395,34 @@
                                     <name>General</name>
                                 </application>
                                 <application>
-                                    <name>Pools</name>
+                                    <name>Main Unit - Pools</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1048576</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Pool Space Used</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>1</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.16.1.2.1.2.1.{#SNMPINDEX}</snmp_oid>
                             <key>eqlStoragePoolStatsSpaceUsed.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>B</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1307,11 +1430,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1048576</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1322,28 +1442,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Pools</name>
+                                    <name>Main Unit - Pools</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1048576</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Pool Space Percent Used</name>
                             <type>15</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>poolpercentused.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>%</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1351,11 +1477,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params>100*last(&quot;eqlStoragePoolStatsSpaceUsed.[\&quot;{#SNMPINDEX}\&quot;]&quot;)/last(&quot;eqlStoragePoolStatsSpace.[\&quot;{#SNMPINDEX}\&quot;]&quot;)</params>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1366,17 +1489,20 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Pools</name>
+                                    <name>Main Unit - Pools</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template Dell Equallogic:poolpercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;98</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic:poolpercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;98</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Pool {ITEM.LASTVALUE} Used</name>
@@ -1392,16 +1518,62 @@
                             <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
-                    <graph_prototypes/>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>{#SNMPVALUE} Pool Space</name>
+                            <width>900</width>
+                            <height>300</height>
+                            <yaxismin>0.0000</yaxismin>
+                            <yaxismax>100.0000</yaxismax>
+                            <show_work_period>1</show_work_period>
+                            <show_triggers>1</show_triggers>
+                            <type>0</type>
+                            <show_legend>1</show_legend>
+                            <show_3d>0</show_3d>
+                            <percent_left>0.0000</percent_left>
+                            <percent_right>0.0000</percent_right>
+                            <ymin_type_1>1</ymin_type_1>
+                            <ymax_type_1>0</ymax_type_1>
+                            <ymin_item_1>0</ymin_item_1>
+                            <ymax_item_1>0</ymax_item_1>
+                            <graph_items>
+                                <graph_item>
+                                    <sortorder>0</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>1A7C11</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>4</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <key>eqlStoragePoolStatsSpace.[&quot;{#SNMPINDEX}&quot;]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <drawtype>0</drawtype>
+                                    <color>F63100</color>
+                                    <yaxisside>0</yaxisside>
+                                    <calc_fnc>4</calc_fnc>
+                                    <type>0</type>
+                                    <item>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                                        <key>eqlStoragePoolStatsSpaceUsed.[&quot;{#SNMPINDEX}&quot;]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>SAN volumes</name>
+                    <name>Main SAN volumes</name>
                     <type>4</type>
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.12740.5.1.7.1.1.4.{$EQL_ID}]</snmp_oid>
                     <key>snmp.discovery.sanvolumes</key>
-                    <delay>3600</delay>
+                    <delay>600</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -1411,7 +1583,6 @@
                     <snmpv3_authpassphrase/>
                     <snmpv3_privprotocol>0</snmpv3_privprotocol>
                     <snmpv3_privpassphrase/>
-                    <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
                     <authtype>0</authtype>
@@ -1425,24 +1596,22 @@
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>30</lifetime>
+                    <lifetime>30d</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Admin Status</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.1.1.9.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1450,11 +1619,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1465,30 +1631,31 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap>
                                 <name>eqliscsiVolumeAdminStatus</name>
                             </valuemap>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Size</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>1</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.1.1.8.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeSize.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>B</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1496,11 +1663,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1000000</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1511,28 +1675,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1000000</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume iSCSI Sessions</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.34.1.5.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeStatsNoOfSessions.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units/>
-                            <delta>2</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1540,11 +1710,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1555,28 +1722,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>9</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Total Read Latency</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.34.1.6.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeStatsReadLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>ms</units>
-                            <delta>1</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1584,11 +1757,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1599,28 +1769,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>10</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Read IOPS</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.34.1.8.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeStatsReadOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>IOps</units>
-                            <delta>1</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1628,11 +1804,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1643,28 +1816,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>10</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Bps received</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.34.1.4.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeStatsRxData.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>Bps</units>
-                            <delta>1</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1672,11 +1851,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1687,28 +1863,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>10</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Bps transmitted</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.34.1.3.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeStatsTxData.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>Bps</units>
-                            <delta>1</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1716,11 +1898,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1731,28 +1910,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>10</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Total Write Latency</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.34.1.7.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeStatsWriteLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>ms</units>
-                            <delta>1</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1760,11 +1945,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1775,28 +1957,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>10</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Write IOPS</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.34.1.9.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeStatsWriteOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>IOps</units>
-                            <delta>1</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1804,11 +1992,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1819,28 +2004,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>10</type>
+                                    <params/>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Allocated Space</name>
                             <type>4</type>
                             <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>1</multiplier>
                             <snmp_oid>.1.3.6.1.4.1.12740.5.1.7.7.1.13.{$EQL_ID}.{#SNMPINDEX}</snmp_oid>
                             <key>eqliscsiVolumeStatusAllocatedSpace.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>B</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1848,11 +2039,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1000000</formula>
-                            <delay_flex/>
                             <params/>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1863,28 +2051,34 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing>
+                                <step>
+                                    <type>1</type>
+                                    <params>1000000</params>
+                                </step>
+                            </preprocessing>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume percent used</name>
                             <type>15</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>volumepercentused.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>%</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1892,11 +2086,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params>100*last(&quot;eqliscsiVolumeStatusAllocatedSpace.[\&quot;{#SNMPINDEX}\&quot;]&quot;)/last(&quot;eqliscsiVolumeSize.[\&quot;{#SNMPINDEX}\&quot;]&quot;)</params>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1907,28 +2098,29 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Average Read Latency</name>
                             <type>15</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>volumeReadAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>ms</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1936,11 +2128,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params>last(&quot;eqliscsiVolumeStatsReadLatency.[\&quot;{#SNMPINDEX}\&quot;]&quot;)/last(&quot;eqliscsiVolumeStatsReadOpCount.[\&quot;{#SNMPINDEX}\&quot;]&quot;)</params>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1951,28 +2140,29 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SNMPVALUE} Volume Average Write Latency</name>
                             <type>15</type>
                             <snmp_community/>
-                            <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>volumeWriteAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                             <delay>300</delay>
-                            <history>7</history>
-                            <trends>365</trends>
+                            <history>7d</history>
+                            <trends>365d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
                             <units>ms</units>
-                            <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
                             <snmpv3_securitylevel>0</snmpv3_securitylevel>
@@ -1980,11 +2170,8 @@
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
                             <params>last(&quot;eqliscsiVolumeStatsWriteLatency.[\&quot;{#SNMPINDEX}\&quot;]&quot;)/last(&quot;eqliscsiVolumeStatsWriteOpCount.[\&quot;{#SNMPINDEX}\&quot;]&quot;)</params>
                             <ipmi_sensor/>
-                            <data_type>0</data_type>
                             <authtype>0</authtype>
                             <username/>
                             <password/>
@@ -1995,17 +2182,20 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Volume</name>
+                                    <name>Main Unit - Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <preprocessing/>
+                            <jmx_endpoint/>
                             <application_prototypes/>
+                            <master_item_prototype/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;1 and {Template Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;2 and {Template Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;4</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;1 and {Custom - HW - Hardware Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;2 and {Custom - HW - Hardware Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;4</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Volume Admin Status</name>
@@ -2021,7 +2211,7 @@
                             <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template Dell Equallogic:volumepercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;99</expression>
+                            <expression>{Custom - HW - Hardware Dell Equallogic:volumepercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;99</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Volume {ITEM.LASTVALUE} Used</name>
@@ -2064,7 +2254,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
                                         <key>eqliscsiVolumeStatsTxData.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2076,7 +2266,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
                                         <key>eqliscsiVolumeStatsRxData.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2108,7 +2298,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
                                         <key>eqliscsiVolumeStatsReadOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2120,7 +2310,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
                                         <key>eqliscsiVolumeStatsWriteOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2152,7 +2342,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
                                         <key>volumeReadAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2164,7 +2354,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Template Dell Equallogic</host>
+                                        <host>Custom - HW - Hardware Dell Equallogic</host>
                                         <key>volumeWriteAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2172,6 +2362,7 @@
                         </graph_prototype>
                     </graph_prototypes>
                     <host_prototypes/>
+                    <jmx_endpoint/>
                 </discovery_rule>
             </discovery_rules>
             <httptests/>
@@ -2186,12 +2377,246 @@
                 </macro>
             </macros>
             <templates/>
-            <screens/>
+            <screens>
+                <screen>
+                    <name>Custom - HW - Hardware Dell Equallogic - Disks</name>
+                    <hsize>1</hsize>
+                    <vsize>1</vsize>
+                    <screen_items>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Disk {#SNMPINDEX} Activity</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>1</max_columns>
+                            <application/>
+                        </screen_item>
+                    </screen_items>
+                </screen>
+                <screen>
+                    <name>Custom - HW - Hardware Dell Equallogic - Fan sensors</name>
+                    <hsize>1</hsize>
+                    <vsize>1</vsize>
+                    <screen_items>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Fan Speed of {#SNMPVALUE}</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>1</max_columns>
+                            <application/>
+                        </screen_item>
+                    </screen_items>
+                </screen>
+                <screen>
+                    <name>Custom - HW - Hardware Dell Equallogic  - Global</name>
+                    <hsize>1</hsize>
+                    <vsize>4</vsize>
+                    <screen_items>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Equallogic -  Read/Write stats</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>3</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>1</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Equallogic -  Storage Usage</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>3</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>0</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>2</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>Equallogic -  Storage Usage Overall</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>3</max_columns>
+                            <application/>
+                        </screen_item>
+                    </screen_items>
+                </screen>
+                <screen>
+                    <name>Custom - HW - Hardware Dell Equallogic - SAN pools</name>
+                    <hsize>1</hsize>
+                    <vsize>1</vsize>
+                    <screen_items>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <width>900</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>{#SNMPVALUE} Pool Space</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>1</max_columns>
+                            <application/>
+                        </screen_item>
+                    </screen_items>
+                </screen>
+                <screen>
+                    <name>Custom - HW - Hardware Dell Equallogic - San Volumes</name>
+                    <hsize>3</hsize>
+                    <vsize>1</vsize>
+                    <screen_items>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <width>500</width>
+                            <height>300</height>
+                            <x>0</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>{#SNMPVALUE} Volume IOPS</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>1</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <width>500</width>
+                            <height>300</height>
+                            <x>1</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>{#SNMPVALUE} Volume Bps</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>1</max_columns>
+                            <application/>
+                        </screen_item>
+                        <screen_item>
+                            <resourcetype>20</resourcetype>
+                            <width>500</width>
+                            <height>300</height>
+                            <x>2</x>
+                            <y>0</y>
+                            <colspan>1</colspan>
+                            <rowspan>1</rowspan>
+                            <elements>0</elements>
+                            <valign>0</valign>
+                            <halign>0</halign>
+                            <style>0</style>
+                            <url/>
+                            <dynamic>0</dynamic>
+                            <sort_triggers>0</sort_triggers>
+                            <resource>
+                                <name>{#SNMPVALUE} Volume Latency</name>
+                                <host>Custom - HW - Hardware Dell Equallogic</host>
+                            </resource>
+                            <max_columns>1</max_columns>
+                            <application/>
+                        </screen_item>
+                    </screen_items>
+                </screen>
+            </screens>
         </template>
     </templates>
     <triggers>
         <trigger>
-            <expression>{Template Dell Equallogic:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Health Status</name>
@@ -2207,7 +2632,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template Dell Equallogic:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
+            <expression>{Custom - HW - Hardware Dell Equallogic:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>low free Storage (&gt;95%)</name>
@@ -2223,7 +2648,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template Dell Equallogic:eqlMemberHealthStatus.nodata(600)}=1</expression>
+            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberHealthStatus.nodata(600)}=1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>no SNMP-Data recieved since &gt;10m</name>
@@ -2239,7 +2664,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template Dell Equallogic:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Hardware Dell Equallogic:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Raid Status</name>
@@ -2257,19 +2682,19 @@
     </triggers>
     <graphs>
         <graph>
-            <name>Read/Write stats</name>
+            <name>Equallogic -  Read/Write stats</name>
             <width>900</width>
-            <height>200</height>
+            <height>300</height>
             <yaxismin>0.0000</yaxismin>
             <yaxismax>100.0000</yaxismax>
             <show_work_period>1</show_work_period>
             <show_triggers>1</show_triggers>
-            <type>0</type>
+            <type>1</type>
             <show_legend>1</show_legend>
             <show_3d>0</show_3d>
             <percent_left>0.0000</percent_left>
             <percent_right>0.0000</percent_right>
-            <ymin_type_1>0</ymin_type_1>
+            <ymin_type_1>1</ymin_type_1>
             <ymax_type_1>0</ymax_type_1>
             <ymin_item_1>0</ymin_item_1>
             <ymax_item_1>0</ymax_item_1>
@@ -2279,10 +2704,10 @@
                     <drawtype>5</drawtype>
                     <color>3333FF</color>
                     <yaxisside>0</yaxisside>
-                    <calc_fnc>2</calc_fnc>
+                    <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Template Dell Equallogic</host>
+                        <host>Custom - HW - Hardware Dell Equallogic</host>
                         <key>eqlMemberReadOpCount</key>
                     </item>
                 </graph_item>
@@ -2291,11 +2716,99 @@
                     <drawtype>5</drawtype>
                     <color>EE0000</color>
                     <yaxisside>0</yaxisside>
-                    <calc_fnc>2</calc_fnc>
+                    <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Template Dell Equallogic</host>
+                        <host>Custom - HW - Hardware Dell Equallogic</host>
                         <key>eqlMemberWriteOpCount</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>Equallogic -  Storage Usage</name>
+            <width>900</width>
+            <height>300</height>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
+            <show_work_period>1</show_work_period>
+            <show_triggers>1</show_triggers>
+            <type>1</type>
+            <show_legend>1</show_legend>
+            <show_3d>0</show_3d>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
+            <ymin_type_1>1</ymin_type_1>
+            <ymax_type_1>0</ymax_type_1>
+            <ymin_item_1>0</ymin_item_1>
+            <ymax_item_1>0</ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>0</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>CC0000</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <key>eqlMemberUsedStorage</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>2774A4</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <key>eqlMemberReplStorage</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>A54F10</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <key>eqlMemberSnapStorage</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>Equallogic -  Storage Usage Overall</name>
+            <width>900</width>
+            <height>300</height>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
+            <show_work_period>1</show_work_period>
+            <show_triggers>1</show_triggers>
+            <type>0</type>
+            <show_legend>1</show_legend>
+            <show_3d>0</show_3d>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
+            <ymin_type_1>1</ymin_type_1>
+            <ymax_type_1>0</ymax_type_1>
+            <ymin_item_1>0</ymin_item_1>
+            <ymax_item_1>0</ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>0</sortorder>
+                    <drawtype>5</drawtype>
+                    <color>BB0000</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>4</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Custom - HW - Hardware Dell Equallogic</host>
+                        <key>MemberUsedStoragePercent</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/zbx3-dell-equallogic.xml
+++ b/zbx3-dell-equallogic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.4</version>
-    <date>2017-12-22T11:35:43Z</date>
+    <date>2017-12-22T12:55:47Z</date>
     <groups>
         <group>
             <name>Template Dell</name>
@@ -12,8 +12,8 @@
     </groups>
     <templates>
         <template>
-            <template>Custom - HW - Dell Equallogic - MainUnit</template>
-            <name>Custom - HW - Dell Equallogic - MainUnit</name>
+            <template>Custom - HW - Dell Equallogic</template>
+            <name>Custom - HW - Dell Equallogic</name>
             <description/>
             <groups>
                 <group>
@@ -25,22 +25,22 @@
             </groups>
             <applications>
                 <application>
+                    <name>Disks</name>
+                </application>
+                <application>
+                    <name>Fan</name>
+                </application>
+                <application>
                     <name>General</name>
                 </application>
                 <application>
-                    <name>Main Unit - Disks</name>
+                    <name>Pools</name>
                 </application>
                 <application>
-                    <name>Main Unit - Fan</name>
+                    <name>Temperature</name>
                 </application>
                 <application>
-                    <name>Main Unit - Pools</name>
-                </application>
-                <application>
-                    <name>Main Unit - Temperature</name>
-                </application>
-                <application>
-                    <name>Main Unit - Volume</name>
+                    <name>Volume</name>
                 </application>
             </applications>
             <items>
@@ -518,7 +518,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlControllerBatteryStatus.[{#SNMPINDEX}].last()}&lt;&gt;1</expression>
+                            <expression>{Custom - HW - Dell Equallogic:eqlControllerBatteryStatus.[{#SNMPINDEX}].last()}&lt;&gt;1</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>Battery Controller Status</name>
@@ -602,7 +602,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Fan</name>
+                                    <name>Fan</name>
                                 </application>
                             </applications>
                             <valuemap>
@@ -646,7 +646,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Fan</name>
+                                    <name>Fan</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -659,7 +659,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}].last()}&lt;&gt;1</expression>
+                            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthDetailsFanCurrentState.[{#SNMPVALUE}].last()}&lt;&gt;1</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>Fan Failure</name>
@@ -702,7 +702,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqlMemberHealthDetailsFanValue.[{#SNMPVALUE}]</key>
                                     </item>
                                 </graph_item>
@@ -858,7 +858,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Temperature</name>
+                                    <name>Temperature</name>
                                 </application>
                             </applications>
                             <valuemap>
@@ -902,7 +902,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Temperature</name>
+                                    <name>Temperature</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -915,7 +915,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
+                            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}].min(#3)}&gt;80</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>High Temperature in {#SNMPVALUE}</name>
@@ -931,7 +931,7 @@
                             <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;1 and {Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;0</expression>
+                            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;1 and {Custom - HW - Dell Equallogic:eqlMemberHealthDetailsTemperatureCurrentState.[{#SNMPVALUE}].max(#2)}&lt;&gt;0</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Temperature Status</name>
@@ -974,7 +974,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqlMemberHealthDetailsTemperatureValue.[{#SNMPVALUE}]</key>
                                     </item>
                                 </graph_item>
@@ -1048,7 +1048,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Disks</name>
+                                    <name>Disks</name>
                                 </application>
                             </applications>
                             <valuemap>
@@ -1092,7 +1092,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Disks</name>
+                                    <name>Disks</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1139,7 +1139,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Disks</name>
+                                    <name>Disks</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1186,7 +1186,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Disks</name>
+                                    <name>Disks</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1233,7 +1233,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Disks</name>
+                                    <name>Disks</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1251,7 +1251,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;1 and {Custom - HW - Dell Equallogic - MainUnit:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2</expression>
+                            <expression>{Custom - HW - Dell Equallogic:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;1 and {Custom - HW - Dell Equallogic:eqlDiskStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Disk 1 Status</name>
@@ -1294,7 +1294,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqlDiskStatusBytesRead.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1306,7 +1306,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqlDiskStatusBytesWritten.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1318,7 +1318,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqlDiskStatusTotalQD.[{#SNMPINDEX}]</key>
                                     </item>
                                 </graph_item>
@@ -1395,7 +1395,7 @@
                                     <name>General</name>
                                 </application>
                                 <application>
-                                    <name>Main Unit - Pools</name>
+                                    <name>Pools</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1442,7 +1442,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Pools</name>
+                                    <name>Pools</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1489,7 +1489,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Pools</name>
+                                    <name>Pools</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1502,7 +1502,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic - MainUnit:poolpercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;98</expression>
+                            <expression>{Custom - HW - Dell Equallogic:poolpercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;98</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Pool {ITEM.LASTVALUE} Used</name>
@@ -1545,7 +1545,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqlStoragePoolStatsSpace.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -1557,7 +1557,7 @@
                                     <calc_fnc>4</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqlStoragePoolStatsSpaceUsed.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -1631,7 +1631,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap>
@@ -1675,7 +1675,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1722,7 +1722,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1769,7 +1769,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1816,7 +1816,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1863,7 +1863,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1910,7 +1910,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -1957,7 +1957,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -2004,7 +2004,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -2051,7 +2051,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -2098,7 +2098,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -2140,7 +2140,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -2182,7 +2182,7 @@
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>Main Unit - Volume</name>
+                                    <name>Volume</name>
                                 </application>
                             </applications>
                             <valuemap/>
@@ -2195,7 +2195,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;1 and {Custom - HW - Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;2 and {Custom - HW - Dell Equallogic - MainUnit:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;4</expression>
+                            <expression>{Custom - HW - Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;1 and {Custom - HW - Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;2 and {Custom - HW - Dell Equallogic:eqliscsiVolumeAdminStatus.[&quot;{#SNMPINDEX}&quot;].last(0)}&lt;&gt;4</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Volume Admin Status</name>
@@ -2211,7 +2211,7 @@
                             <tags/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Custom - HW - Dell Equallogic - MainUnit:volumepercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;99</expression>
+                            <expression>{Custom - HW - Dell Equallogic:volumepercentused.[&quot;{#SNMPINDEX}&quot;].last(0)}&gt;99</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>{#SNMPVALUE} Volume {ITEM.LASTVALUE} Used</name>
@@ -2254,7 +2254,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqliscsiVolumeStatsTxData.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2266,7 +2266,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqliscsiVolumeStatsRxData.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2298,7 +2298,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqliscsiVolumeStatsReadOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2310,7 +2310,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>eqliscsiVolumeStatsWriteOpCount.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2342,7 +2342,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>volumeReadAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2354,7 +2354,7 @@
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
-                                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                        <host>Custom - HW - Dell Equallogic</host>
                                         <key>volumeWriteAvgLatency.[&quot;{#SNMPINDEX}&quot;]</key>
                                     </item>
                                 </graph_item>
@@ -2400,7 +2400,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Disk {#SNMPINDEX} Activity</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2429,7 +2429,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Fan Speed of {#SNMPVALUE}</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2458,7 +2458,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Read/Write stats</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2480,7 +2480,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Storage Usage</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2502,7 +2502,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>Equallogic -  Storage Usage Overall</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>3</max_columns>
                             <application/>
@@ -2531,7 +2531,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Pool Space</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2560,7 +2560,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume IOPS</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2582,7 +2582,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume Bps</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2604,7 +2604,7 @@
                             <sort_triggers>0</sort_triggers>
                             <resource>
                                 <name>{#SNMPVALUE} Volume Latency</name>
-                                <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                                <host>Custom - HW - Dell Equallogic</host>
                             </resource>
                             <max_columns>1</max_columns>
                             <application/>
@@ -2616,7 +2616,7 @@
     </templates>
     <triggers>
         <trigger>
-            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthStatus.max(#2)}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Health Status</name>
@@ -2632,7 +2632,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Dell Equallogic - MainUnit:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
+            <expression>{Custom - HW - Dell Equallogic:MemberUsedStoragePercent.min(#2)}&gt;95</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>low free Storage (&gt;95%)</name>
@@ -2648,7 +2648,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberHealthStatus.nodata(600)}=1</expression>
+            <expression>{Custom - HW - Dell Equallogic:eqlMemberHealthStatus.nodata(600)}=1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>no SNMP-Data recieved since &gt;10m</name>
@@ -2664,7 +2664,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Custom - HW - Dell Equallogic - MainUnit:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
+            <expression>{Custom - HW - Dell Equallogic:eqlMemberRaidStatus.last()}&lt;&gt;1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>Raid Status</name>
@@ -2707,7 +2707,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic</host>
                         <key>eqlMemberReadOpCount</key>
                     </item>
                 </graph_item>
@@ -2719,7 +2719,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic</host>
                         <key>eqlMemberWriteOpCount</key>
                     </item>
                 </graph_item>
@@ -2751,7 +2751,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic</host>
                         <key>eqlMemberUsedStorage</key>
                     </item>
                 </graph_item>
@@ -2763,7 +2763,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic</host>
                         <key>eqlMemberReplStorage</key>
                     </item>
                 </graph_item>
@@ -2775,7 +2775,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic</host>
                         <key>eqlMemberSnapStorage</key>
                     </item>
                 </graph_item>
@@ -2807,7 +2807,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Custom - HW - Dell Equallogic - MainUnit</host>
+                        <host>Custom - HW - Dell Equallogic</host>
                         <key>MemberUsedStoragePercent</key>
                     </item>
                 </graph_item>


### PR DESCRIPTION
A improved template, ready for zabbix 3.4.

- Renamed template from "Template Dell Equallogic" to "Custom - HW - Dell Equallogic"
  to clearly distinguish it from default templates
- improved the graphs
- added various host screens, which utilize graph prototypes to easily review
  the various measured values
- improved logic for temperature warning, gather and use adequate unit limits from the
  system itself